### PR TITLE
ignore non-issue events

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -59,7 +59,8 @@ def main(params):
     # in params['__ow_headers']['X-Hub-Signature']
     
     # We get a number of events when an issue is opened. We will just act on the label event
-    if not (params['issue']['state'] == 'open' and 
+    if not ('issue' in params and
+            params['issue']['state'] == 'open' and 
             params['action'] == 'labeled' and
             params['label']['name'] == create_needed_label ):
         return bot_status(None, 'no_action_needed')


### PR DESCRIPTION
Even when the webhook is configured to only send issue event, the action of adding the webhook is sent, and is a non-issue event, meaning that the 'issue' key is not available in the json object causing a failure.
It can also be assumed that some bad webhook configurations will be configured from time to time, sending other non-issue events.
So to keep a cleaner log of action triggers we'll make sure to check for the availability of the 'issue' key first.